### PR TITLE
Fixing Access Token retrieval to use latest FB Auth flow

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -23,9 +23,8 @@ class Tests(object):
             facebook_username = input('What is your Facebook username?\n')
             facebook_password = getpass.getpass()
             facebook_access_token = facebook_auth_token.get_facebook_access_token(facebook_username, facebook_password)
-            facebook_user_id = facebook_auth_token.get_facebook_id(facebook_access_token)
-            api_token = self._tinder_api.get_facebook_auth_token(facebook_auth_token, facebook_user_id)
-        print("Your api token is '{api_token}'. Please make not of it.\n".format(api_token=api_token))
+            api_token = self._tinder_api.get_facebook_auth_token(facebook_access_token)
+        print("Your api token is '{api_token}'. Please make a note of it.\n".format(api_token=api_token))
 
 
     def authenticate(self, api_token):

--- a/tinder_api/api.py
+++ b/tinder_api/api.py
@@ -1,19 +1,20 @@
 # coding=utf-8
-'''
+"""
 Tinder API python wrapper
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Read `readme.md` and `Tinder API.ipnyb` for usage.
 
 :license: MIT, see LICENSE for more details.
-'''
+"""
 
 import json
 import requests
 from tinder_api.api_endpoints import API_ENDPOINTS
 
+
 class Tinder_API(object):
-    def __init__(self, host= 'https://api.gotinder.com', headers={}, api_token=None):
+    def __init__(self, host='https://api.gotinder.com', headers={}, api_token=None):
         self._host = host
         self._not_authenticated_error = {'error': 'Please authenticate first.'}
         self._API_ENDPOINTS = API_ENDPOINTS
@@ -29,110 +30,100 @@ class Tinder_API(object):
         if api_token is not None:
             self.authenticate(api_token)
 
-
     # AUTHENTICATION METHODS
 
     def authenticate(self, api_token):
-        '''
+        """
         Sets the authenticate header attribute.
-        '''
+        """
         self._headers.update({self._auth_key: api_token})
-
 
     # SMS authentication
 
     def send_otp_code(self, phone_number):
-        '''
+        """
         Request a one time password from Tinder via SMS.
 
         :param phone_number: the phone number to send the otp to.
-        '''
+        """
         return self.api_request('auth', 'smsSend', data={'phone_number': phone_number})
 
-
     def get_refresh_token(self, phone_number, otp_code):
-        '''
+        """
         Gets the refresh token.
 
         :param phone_number: the user's phone number.
 
         :param otp_code: received by the user on the number provided.
-        '''
-        response_body = self.api_request('auth', 'smsValidate', data={'otp_code': otp_code, 'phone_number': phone_number})
+        """
+        response_body = self.api_request('auth', 'smsValidate',
+                                         data={'otp_code': otp_code, 'phone_number': phone_number})
         return response_body.get("data", {}).get("refresh_token")
 
-
     def get_api_token(self, refresh_token):
-        '''
+        """
         Gets the API token from the refresh token. Will also authenticate.
 
         :param refresh_token: Refresh token obtained from :method:`get_refresh_token`.
-        '''
-        data = {'refresh_token': refresh_token }
+        """
+        data = {'refresh_token': refresh_token}
         response_body = self.custom_request(self._API_ENDPOINTS['authApiPath'] + '/sms', http_verb='POST', data=data)
         api_token = response_body.get("data", {}).get("api_token", None)
         self.authenticate(api_token)
         return api_token
 
-
     # FB authentication
 
-    def get_facebook_auth_token(self, facebook_auth_token, facebook_user_id):
-        '''
+    def get_facebook_auth_token(self, facebook_auth_token):
+        """
         Get api_token using Facebook.
 
         :param facebook_auth_token: the Facebook auth token of the user to authenticate.
-
-        :param facebook_user_id: the Facebook ID of the user to authenticate.
-        '''
-        response_body = self.custom_request('/auth', http_verb='POST', data={'facebook_token': facebook_auth_token, 'facebook_id': facebook_user_id})
-        token = response_body['token']
+        """
+        response_body = self.custom_request(self._API_ENDPOINTS['authApiPath'] + '/facebook',
+                                            http_verb='POST',
+                                            data={'token': facebook_auth_token})
+        token = response_body['data']['api_token']
         self.authenticate(token)
         return token
-
 
     # APP FUNCTIONALITY
 
     def get_recommendations(self):
-        '''
+        """
         Returns a list of users that you can swipe on.
-        '''
+        """
         return self.custom_request('/user/recs')
 
-
     def get_recs_v2(self):
-        '''
+        """
         This works more consistently then the normal get_recommendations becuase it seeems to check new location.
-        '''
+        """
         return self.api_request('recs', 'getRecs')
 
-
     def get_updates(self, last_activity_date=None):
-        '''
+        """
         Returns all updates since the given activity date.
 
         :param last_activity_date: The last activity date is defaulted at the beginning of time.
             Format: '2017-07-09T10:28:13.392Z'
-        '''
+        """
         return self.api_request('user', 'getUpdates', data={'last_activity_date': last_activity_date})
 
-
     def get_self(self):
-        '''
+        """
         Returns your own profile data
-        '''
+        """
         return self.custom_request('/profile')
 
-
     def get_self_v2(self):
-        '''
+        """
         Returns your own profile data. Does not seem to work.
-        '''
+        """
         return self.api_request('profile', 'getUserProfile')
 
-
     def change_preferences(self, preferences):
-        '''
+        """
         Changes your search preferences.
 
         :param kwargs: a dictionary:
@@ -145,126 +136,115 @@ class Tinder_API(object):
             {'photo_optimizer_enabled':false}
         
         example: change_preferences(age_filter_min=30, gender=0)
-        '''
+        """
         return self.custom_request('/profile', http_verb='POST', data=preferences)
 
-
     def get_meta(self):
-        '''
+        """
         Returns meta data on yourself. Including the following keys:
         ['globals', 'client_resources', 'versions', 'purchases',
         'status', 'groups', 'products', 'rating', 'tutorials',
         'travel', 'notifications', 'user']
-        '''
+        """
         return self.custom_request('/meta')
 
-
     def get_meta_v2(self):
-        '''
+        """
         Returns meta data on yourself from V2 API. Including the following keys:
         ['account', 'client_resources', 'plus_screen', 'boost',
         'fast_match', 'top_picks', 'paywall', 'merchandising', 'places',
         'typing_indicator', 'profile', 'recs']
-        '''
+        """
         return self.api_request('meta', 'getMeta')
 
-
     def update_location(self, lat, lon):
-        '''
+        """
         Updates your location to the given float inputs.
         Note: Requires a passport / Tinder Plus.
 
         :param lat: latitude.
 
         :param lon: longitude.
-        '''
+        """
         return self.api_request('passport', 'submitPassportLocation', data={'lat': lat, 'lon': lon})
 
     def reset_real_location(self):
-        '''
+        """
         Reset your real location.
         Note: Requires a passport / Tinder Plus.
-        '''
+        """
         return self.api_request('passport', 'resetPassportLocation')
 
-
     def set_webprofileusername(self, username):
-        '''
+        """
         Sets the username for the webprofile.
 
         :param username: string
             ex: https://www.gotinder.com/@YOURUSERNAME
-        '''
+        """
         return self.custom_request('/profile/username', http_verb='PUT', data={'username': username})
 
     def reset_webprofileusername(self, username):
-        '''
+        """
         Resets the username for the webprofile
 
         :param username: ?
-        '''
+        """
         return self.custom_request('/profile/username', http_verb='DELETE')
 
-
     def get_person(self, id):
-        '''
+        """
         Gets a user's profile via their id
 
         :param id: ID of the user to find
-        '''
+        """
         return self.api_request('user', 'getOtherUserById', userId=id)
 
-
     def send_msg(self, match_id, msg):
-        '''
+        """
         Send a message to a match
 
         :param match_id: match
 
         :param msg: message to send
-        '''
+        """
         return self.api_request('user', 'sendMessage', data={'message': msg}, matchId=match_id)
 
-
     def unmatch(self, match_id):
-        '''
+        """
         Unmatch someone
 
         :param match_id: person to unmatch
-        '''
+        """
         return self.api_request('user', 'unmatch', matchId=match_id)
 
-
     def superlike(self, user_id):
-        '''
+        """
         Superlike someone
 
         :param user_id: person to superlike
-        '''
+        """
         return self.like(user_id, action='superlike')
 
-
     def like(self, user_id, action='like'):
-        '''
+        """
         Like someone
 
         :param user_id: person to like
-        '''
+        """
         endpoint = {'superlike': 'recSuperLike', 'like': 'recLike', 'dislike': 'recDislike'}[action]
         return self.api_request('recs', endpoint, userId=user_id)
 
-
     def dislike(self, user_id):
-        '''
+        """
         Dislike someone
 
         :param user_id: person to dislike
-        '''
+        """
         return self.like(user_id, action='dislike')
 
-
     def report(self, user_id, cause, explanation=''):
-        '''
+        """
         Report someone
         
         :param cause: There are three options for cause:
@@ -273,64 +253,57 @@ class Tinder_API(object):
             4 : Inappropriate Photos and no explanation
 
         :param explanation: optional user comment
-        '''
+        """
         return self.api_request('report', 'reportUser', data={'cause': cause, 'text': explanation}, userId=user_id)
 
-
     def get_match(self, match_id):
-        '''
+        """
         Get info from match
 
         :param match_id: ID of the match to get info about
-        '''
+        """
         return self.api_request('user', 'getMatch', matchId=match_id)
 
-
     def matches(self, limit=60, page_token=None):
-        '''
+        """
         Get matches, in increments of roughly 60. Use the page token in the response to obtain the next set.
 
         :param limit: maximum number of matches to get.
 
         :param page_token: Page offset. Obtained in this function's response.
-        '''
+        """
         return self.api_request('user', 'getMatches', data={'count': limit, 'page_token': page_token})
 
-
     def fast_match_count(self):
-        '''
+        """
         Get your match count. Returns a value between 0 and 99.
-        '''
+        """
         return self.api_request('recs', 'fastMatchCount')
 
-    
     def fast_match_teasers(self):
-        '''
+        """
         Get the non blurred thumbnail image shown in the messages-window (the one showing the likes you received).
-        '''
+        """
         return self.api_request('recs', 'fastMatchTeasers')
 
-
     def trending_gifs(self, limit=3):
-        '''
+        """
         Get trending GIFs.
 
         :param limit: limit to the number of results.
-        '''
+        """
         return self.api_request('gif', 'trending', data={'limit': limit})
 
-
     def gif_query(self, query, limit=3):
-        '''
+        """
         Search for GIFs.
 
         :param limit: limit to the number of results.
-        '''
+        """
         return self.api_request('gif', 'search', data={'limit': limit, 'query': query})
 
-
-    def api_request(self, service, endpoint, data={}, **kwargs):
-        '''
+    def api_request(self, service, endpoint, data=None, **kwargs):
+        """
         Perform an API request to the service and endpoint provided, with the data provided.
 
         :param service: Tinder API service from `api_endpoints.json`.
@@ -339,18 +312,19 @@ class Tinder_API(object):
 
         :param data: data to send with the request.
 
-        :return: :class:`requests.Reponse`
-        '''
+        :return: :class:`requests.Response`
+        """
+        if data is None:
+            data = {}
         api_endpoint = self.get_endpoint(service, endpoint)
-        return self.custom_request(api_endpoint.get('path').format(**kwargs), http_verb=api_endpoint.get('method', 'GET'), data=data)
+        return self.custom_request(api_endpoint.get('path').format(**kwargs),
+                                   http_verb=api_endpoint.get('method', 'GET'), data=data)
 
-    
     def get_endpoint(self, service, endpoint):
         return self._API_ENDPOINTS['services'].get(service)['endpoints'].get(endpoint)
 
-
-    def custom_request(self, endpoint, http_verb='get', data={}):
-        '''
+    def custom_request(self, endpoint, http_verb='get', data=None):
+        """
         Allow calling any endpoint of the Tinder API.
 
         :param endpoint: endpoint (part of the link after host).
@@ -364,14 +338,20 @@ class Tinder_API(object):
             Can be: get, head, post, patch, put, delete, options
 
         :return: response object
-        '''
+        """
+        if data is None:
+            data = {}
         if self._auth_key not in self._headers and '/auth' not in endpoint:
             return self._not_authenticated_error
-        
-        http_verb_functions={ 'get': requests.get, 'head': requests.head, 'post': requests.post, 'patch': requests.patch, 'put': requests.put, 'delete': requests.delete, 'options': requests.options }
-        request_has_body={ 'get': False, 'head': False, 'post': True, 'patch': True, 'put': True, 'delete': True, 'options': False }
-        response_has_body={ 'get': True, 'head': False, 'post': True, 'patch': True, 'put': False, 'delete': True, 'options': True }
-        
+
+        http_verb_functions = {'get': requests.get, 'head': requests.head, 'post': requests.post,
+                               'patch': requests.patch, 'put': requests.put, 'delete': requests.delete,
+                               'options': requests.options}
+        request_has_body = {'get': False, 'head': False, 'post': True, 'patch': True, 'put': True, 'delete': True,
+                            'options': False}
+        response_has_body = {'get': True, 'head': False, 'post': True, 'patch': True, 'put': False, 'delete': True,
+                             'options': True}
+
         http_verb = http_verb.lower()
         url = self._host + endpoint
         http_verb_function = http_verb_functions[http_verb.lower()]
@@ -389,15 +369,15 @@ class Tinder_API(object):
         except Exception as e:
             return {'error': 'Something went wrong.', 'exception': str(e)}
 
-
     def data_to_query_string(self, data):
-        '''
+        """
         Converts a dict into a query string
 
         :param data: data to be included in a query string
 
         :return: query string
-        '''
+        """
         if type(data) is dict and data != {}:
-            return '?' + '&'.join([f"{key}={value}" for key, value in data.items() if value is not None and value != ''])
+            return '?' + '&'.join(
+                [f"{key}={value}" for key, value in data.items() if value is not None and value != ''])
         return ''

--- a/tinder_api/facebook_auth_token.py
+++ b/tinder_api/facebook_auth_token.py
@@ -12,7 +12,7 @@ import robobrowser
 
 MOBILE_USER_AGENT = 'Tinder/7.5.3 (iPhone; iOS 10.3.2; Scale/2.00)'
 FACEBOOK_AUTH = 'https://www.facebook.com/v2.6/dialog/oauth?redirect_uri=fb464891386855067%3A%2F%2Fauthorize%2F&display=touch&state=%7B%22challenge%22%3A%22IUUkEUqIGud332lfu%252BMJhxL4Wlc%253D%22%2C%220_auth_logger_id%22%3A%2230F06532-A1B9-4B10-BB28-B29956C71AB1%22%2C%22com.facebook.sdk_client_state%22%3Atrue%2C%223_method%22%3A%22sfvc_auth%22%7D&scope=user_birthday%2Cuser_photos%2Cuser_education_history%2Cemail%2Cuser_relationship_details%2Cuser_friends%2Cuser_work_history%2Cuser_likes&response_type=token%2Csigned_request&default_audience=friends&return_scopes=true&auth_type=rerequest&client_id=464891386855067&ret=login&sdk=ios&logger_id=30F06532-A1B9-4B10-BB28-B29956C71AB1&ext=1470840777&hash=AeZqkIcf-NEW6vBd'
-
+COOKIE = {'datr': 'QPfMYSxhry4rroXCVDe4_geS'}
 
 def get_facebook_access_token(email, password):
     '''
@@ -22,16 +22,19 @@ def get_facebook_access_token(email, password):
     :param password: Facebook password.
     '''
     s = robobrowser.RoboBrowser(user_agent=MOBILE_USER_AGENT, parser='lxml')
+    s.session.cookies.update(COOKIE)
     s.open(FACEBOOK_AUTH)
+
     f = s.get_form()
     f['pass'] = password
     f['email'] = email
     s.submit_form(f)
     f = s.get_form()
+
     try:
-        s.submit_form(f, submit=f.submit_fields['__CONFIRM__'])
+        s.submit_form(f, submit=f.submit_fields['__CONFIRM__'], allow_redirects=False)
         access_token = re.search(
-            r"access_token=([\w\d]+)", s.response.content.decode()).groups()[0]
+            r"access_token=([\w\d]+)", s.response.headers['Location']).groups()[0]
         return access_token
     except Exception as ex:
         return {'error': 'access token could not be retrieved. Check your username and password.', 'exception': str(ex)}


### PR DESCRIPTION
I noticed that the access_token retrieval functions weren't working, and after a bit of debugging found that the library needs to tweak how it interacts with the login page (getting rid of the Cookie page, and ignoring the always-fatal redirect.

I also fixed the tests and some formatting, but let me know if that's too much and I can revert it